### PR TITLE
Add GossipNetwork.AlgorandTestNet for gossip discovery

### DIFF
--- a/dotnet-algorand-sdk/Gossip/GossipHttpConfiguration.cs
+++ b/dotnet-algorand-sdk/Gossip/GossipHttpConfiguration.cs
@@ -21,7 +21,10 @@ namespace Algorand.Gossip
         AlgorandMainNet,
         VoiMainNet,
         AramidMainNetBiatec,
-        AramidMainNetAWallet
+        AramidMainNetAWallet,
+        // Appended rather than inserted alongside AlgorandMainNet so existing members keep their
+        // underlying int values for anyone persisting/comparing this enum numerically.
+        AlgorandTestNet
     }
 
     public class GossipHttpConfiguration
@@ -94,6 +97,9 @@ namespace Algorand.Gossip
                 case GossipNetwork.AlgorandMainNet:
                     domain = "mainnet.algorand.network";
                     break;
+                case GossipNetwork.AlgorandTestNet:
+                    domain = "testnet.algorand.network";
+                    break;
                 case GossipNetwork.VoiMainNet:
                     domain = "voimain.mainnet-voi.network";
                     break;
@@ -119,6 +125,8 @@ namespace Algorand.Gossip
             {
                 case GossipNetwork.AlgorandMainNet:
                     return "mainnet-v1.0";
+                case GossipNetwork.AlgorandTestNet:
+                    return "testnet-v1.0";
                 case GossipNetwork.VoiMainNet:
                     return "voimain-v1.0";
                 case GossipNetwork.AramidMainNetBiatec:

--- a/test/Gossip/GossipHttpConfigurationTests.cs
+++ b/test/Gossip/GossipHttpConfigurationTests.cs
@@ -92,6 +92,8 @@ namespace test.Gossip
 
         [TestCase(GossipNodePurpose.Archival, GossipNetwork.AlgorandMainNet, "_archive._tcp.mainnet.algorand.network")]
         [TestCase(GossipNodePurpose.Relay, GossipNetwork.AlgorandMainNet, "_algobootstrap._tcp.mainnet.algorand.network")]
+        [TestCase(GossipNodePurpose.Archival, GossipNetwork.AlgorandTestNet, "_archive._tcp.testnet.algorand.network")]
+        [TestCase(GossipNodePurpose.Relay, GossipNetwork.AlgorandTestNet, "_algobootstrap._tcp.testnet.algorand.network")]
         [TestCase(GossipNodePurpose.Archival, GossipNetwork.VoiMainNet, "_archive._tcp.voimain.mainnet-voi.network")]
         [TestCase(GossipNodePurpose.Relay, GossipNetwork.VoiMainNet, "_algobootstrap._tcp.voimain.mainnet-voi.network")]
         [TestCase(GossipNodePurpose.Archival, GossipNetwork.AramidMainNetBiatec, "_archive._tcp.aramidmain.biatec.io")]
@@ -104,6 +106,7 @@ namespace test.Gossip
         }
 
         [TestCase(GossipNetwork.AlgorandMainNet, "mainnet-v1.0")]
+        [TestCase(GossipNetwork.AlgorandTestNet, "testnet-v1.0")]
         [TestCase(GossipNetwork.VoiMainNet, "voimain-v1.0")]
         [TestCase(GossipNetwork.AramidMainNetBiatec, "aramidmain-v1.0")]
         [TestCase(GossipNetwork.AramidMainNetAWallet, "aramidmain-v1.0")]
@@ -128,6 +131,8 @@ namespace test.Gossip
         // records (mirrors test.Gossip.BlockFetcherTests, which hits MainNet gossip nodes directly).
         [TestCase(GossipNodePurpose.Archival, GossipNetwork.AlgorandMainNet)]
         [TestCase(GossipNodePurpose.Relay, GossipNetwork.AlgorandMainNet)]
+        [TestCase(GossipNodePurpose.Archival, GossipNetwork.AlgorandTestNet)]
+        [TestCase(GossipNodePurpose.Relay, GossipNetwork.AlgorandTestNet)]
         [TestCase(GossipNodePurpose.Archival, GossipNetwork.VoiMainNet)]
         [TestCase(GossipNodePurpose.Relay, GossipNetwork.VoiMainNet)]
         [TestCase(GossipNodePurpose.Archival, GossipNetwork.AramidMainNetBiatec)]


### PR DESCRIPTION
## Summary
- `GossipNetwork` previously had no testnet member (only `AlgorandMainNet`, `VoiMainNet`, `AramidMainNetBiatec`, `AramidMainNetAWallet`), so any consumer relying on dynamic DNS SRV discovery (no static relay list configured) had no way to run against Algorand testnet - `GossipHttpConfiguration`'s constructor would throw `ArgumentOutOfRangeException` for anything else. Hit this directly in AVMTradeReporter's new testnet stage environment.
- Adds `GossipNetwork.AlgorandTestNet`, mapped to the standard `testnet.algorand.network` SRV domain (same `_algobootstrap._tcp` / `_archive._tcp` convention already used for `mainnet.algorand.network`) and genesis ID `testnet-v1.0`.
- Verified live before opening this PR - both SRV records currently resolve:
  - `_algobootstrap._tcp.testnet.algorand.network` -> `r-99`, `r-tq`, `r-hn`, `r-ty`, `r-mt`, `r-5i`, `r-po`, `r-f4`.algorand-testnet.network:4161
  - `_archive._tcp.testnet.algorand.network` -> `a-ff`, `a-4y`, `a-6s`, `a-bu`.algorand-testnet.network:4161
- Appended as the last enum member (not inserted next to `AlgorandMainNet`) so existing members keep their current underlying `int` values for anyone persisting/comparing this enum numerically.
- Opening against this fork (not just upstream) because `publish-nuget.yml` here is what actually publishes the `Algorand4` NuGet package AVMTradeReporter consumes - merging here (in addition to/independent of the upstream PR) is what's needed to get this into a release.

## Test plan
- [x] `dotnet build dotnet-algorand-sdk/dotnet-algorand-sdk.csproj -c Release` succeeds
- [x] `dotnet test test/test.csproj --filter "FullyQualifiedName~GossipHttpConfigurationTests"` - 32/32 passed, including new `AlgorandTestNet` cases that hit live DNS SRV resolution